### PR TITLE
node-sass binary prebuild

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -39,6 +39,18 @@ RUN git clone https://github.com/sass/sassc && cd sassc && \
     apk add libstdc++ && \
     rm -rf /var/cache/apk/*
 
+# created node-sass binary
+ENV SASS_BINARY_PATH=/usr/lib/node_modules/node-sass/build/Release/binding.node'
+RUN git clone --recursive https://github.com/sass/node-sass.git && \
+    cd node-sass && \
+    git submodule update --init --recursive && \
+    npm install && \
+    node scripts/build -f && \
+    cd ../ && rm -rf node-sass
+
+# add binary path of node-sass to .npmrc
+RUN touch $HOME/.npmrc && echo "sass_binary_cache=${SASS_BINARY_PATH}" >> $HOME/.npmrc
+
 # npm@3 install bug for Docker aufs
 RUN cd $(npm root -g)/npm && \
     npm install fs-extra && \

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ Ruby Node.js container
 
 > In this Dockerfile by using the ndenv you have installed the Node.js
 > The following package has already been installed together
-> phantomjs, libsass
+> phantomjs, libsass, node-sass
 
 Installation
 -----


### PR DESCRIPTION
Add node-sass prebuild .
Binary path is ```/usr/lib/node_modules/node-sass/build/Release/binding.node```

```sh
echo $SASS_BINARY_PATH # => /usr/lib/node_modules/node-sass/build/Release/binding.node
```

```.npmrc``` is setting the setting value ```sass_binary_cache= /usr/lib/node_modules/node-sass/build/Release/binding.node``` 